### PR TITLE
Stack growth 구현

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,16 @@
       "remote": true,
       "cwd": "${workspaceRoot}",
       "valuesFormatting": "parseText"
+    },
+    {
+      "type": "gdb",
+      "request": "attach",
+      "name": "Attach to gdbserver : vm",
+      "executable": "${workspaceRoot}/vm/build/kernel.o",
+      "target": "localhost:1234",
+      "remote": true,
+      "cwd": "${workspaceRoot}",
+      "valuesFormatting": "parseText"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "list.h": "c",
     "process.h": "c",
     "uninit.h": "c",
-    "vm.h": "c"
+    "vm.h": "c",
+    "vaddr.h": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
     "process.h": "c",
     "uninit.h": "c",
     "vm.h": "c",
-    "vaddr.h": "c"
+    "vaddr.h": "c",
+    "anon.h": "c",
+    "file.h": "c"
   }
 }

--- a/include/lib/kernel/hash.h
+++ b/include/lib/kernel/hash.h
@@ -1,6 +1,14 @@
 #ifndef __LIB_KERNEL_HASH_H
 #define __LIB_KERNEL_HASH_H
 
+/* 해시 테이블.
+ * 이 데이터 구조는 프로젝트 3을 위한 Pintos 투어에서 철저히 문서화되어 있습니다.
+ * 이것은 체이닝을 사용하는 표준 해시 테이블입니다. 
+ * 테이블에서 요소를 찾기 위해 요소의 데이터에 대한 해시 함수를 계산하고 그것을 이중 연결 리스트 배열의 인덱스로 사용한 다음 리스트를 선형으로 검색합니다.
+ * 체인 리스트는 동적 할당을 사용하지 않습니다. 대신 해시에 있을 수 있는 각 구조체는 반드시 struct hash_elem 멤버를 내장해야 합니다. 
+ * 모든 해시 함수는 이러한 'struct hash_elem'에서 작동합니다. 
+ * hash_entry 매크로는 struct hash_elem을 포함하는 구조체 객체로의 변환을 허용합니다. 
+ * 이는 연결 리스트 구현에서 사용되는 동일한 기술입니다. 자세한 설명은 lib/kernel/list.h를 참조하세요.*/
 /* Hash table.
  *
  * This data structure is thoroughly documented in the Tour of
@@ -30,6 +38,8 @@ struct hash_elem {
 	struct list_elem list_elem;
 };
 
+/* 해시 요소인 HASH_ELEM의 포인터를 HASH_ELEM이 포함된 구조체의 포인터로 변환합니다.
+ * 바깥 구조체의 이름 STRUCT와 해시 요소의 멤버 이름 MEMBER를 제공하세요. 파일 맨 위의 큰 주석에서 예제를 참조하세요.*/
 /* Converts pointer to hash element HASH_ELEM into a pointer to
  * the structure that HASH_ELEM is embedded inside.  Supply the
  * name of the outer structure STRUCT and the member name MEMBER

--- a/include/threads/interrupt.h
+++ b/include/threads/interrupt.h
@@ -46,6 +46,10 @@ struct intr_frame {
 	uint32_t __pad4;
 	/* Pushed by intrNN_stub in intr-stubs.S. */
 	uint64_t vec_no; /* Interrupt vector number. */
+
+/* CPU에 의해 가끔 푸시되며,
+그 외의 경우에는 일관성을 위해 intrNN_stub에 의해 0으로 푸시됩니다.
+CPU는 이것을 eip 바로 아래에 놓지만, 우리는 여기로 옮깁니다. */
 /* Sometimes pushed by the CPU,
    otherwise for consistency pushed as 0 by intrNN_stub.
    The CPU puts it just under `eip', but we move it here. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -162,6 +162,10 @@ struct thread {
 
     /* Owned by thread.c. */
     struct intr_frame tf; /* Information for switching */
+    
+    /* 할당받은 시점의 stack 주소 */
+    void *rsp;
+
 
     struct list child_list;
     struct list_elem child_elem;

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -1,7 +1,7 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 #define USERPROG    // project2 잠금 해제
-// #define VM          // project3 잠금 해제
+#define VM          // project3 잠금 해제
 
 #include <debug.h>
 #include <list.h>

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -60,8 +60,10 @@ struct page {
 	
 	/* Your implementation */ /* 여러분의 구현 */
 	struct hash_elem hash_elem;
+	bool is_writable;
+
 	/* 페이지가 중복으로 여러 곳에 저장될 수 있으므로! */
-	bool is_exist_memory;
+	bool is_exist_frame;
 	bool is_exist_swap;
 	bool is_exist_disk;
 	

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -46,6 +46,13 @@ struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
 
+struct aux {
+	struct file *file;
+	off_t ofs;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
+};
+
 /* "페이지"의 표현입니다.
  * 이는 네 개의 "자식 클래스"인 uninit_page, file_page, anon_page 및 페이지 캐시 (프로젝트 4)를 가진 "부모 클래스"의 종류입니다.
  * 이 구조체의 사전 정의된 멤버를 제거하거나 수정하지 마십시오. */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -19,14 +19,14 @@ enum vm_type {
 	/* page that hold the page cache, for project 4 */
 	VM_PAGE_CACHE = 3,
 
-	
+	/* 스택 페이지 표시 */
+	VM_MARKER_0 = (1 << 3),
+
 	/* 상태를 저장하는 비트 플래그 */
 	/* Bit flags to store state */
-
 	/* 정보를 저장하는 보조 비트 플래그 표시기입니다. int에 값이 맞을 때까지 더 많은 표시기를 추가할 수 있습니다. */
 	/* Auxillary bit flag marker for store information. You can add more
 	 * markers, until the value is fit in the int. */
-	VM_MARKER_0 = (1 << 3),
 	VM_MARKER_1 = (1 << 4),
 
 	/* 이 값 이상으로는 초과하지 마십시오. */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,8 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include <hash.h>
+
 
 enum vm_type {
 	/* 페이지가 초기화되지 않음 */
@@ -55,10 +57,14 @@ struct page {
 	const struct page_operations *operations;
 	void *va;              /* Address in terms of user space */ /* 사용자 공간에서의 주소 */
 	struct frame *frame;   /* Back reference for frame */ /* 프레임에 대한 역 참조 */
-
+	
 	/* Your implementation */ /* 여러분의 구현 */
-
-
+	struct hash_elem hash_elem;
+	/* 페이지가 중복으로 여러 곳에 저장될 수 있으므로! */
+	bool is_exist_memory;
+	bool is_exist_swap;
+	bool is_exist_disk;
+	
 	/* 각 유형의 데이터는 연합체에 바인딩됩니다.
 	 * 각 함수는 자동으로 현재의 연합체를 감지합니다. */
 	/* Per-type data are binded into the union.
@@ -107,7 +113,12 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash hash_pages;
+	// todo : 보조 페이지 구조체 만들기
+	// 보조 페이지의 테이블
+
 };
+
 
 #include "threads/thread.h"
 void supplemental_page_table_init (struct supplemental_page_table *spt);

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -38,6 +38,14 @@ hash_init (struct hash *h,
 		return false;
 }
 
+/* H에서 모든 요소를 제거합니다.
+
+   DESTRUCTOR가 null이 아니면 해시의 각 요소에 대해 호출됩니다.
+   DESTRUCTOR는 적절한 경우 해시 요소에 사용된 메모리를 해제할 수 있습니다.
+   그러나 hash_clear()가 실행되는 동안 해시 테이블 H를 수정하는 것은
+   hash_clear(), hash_destroy(), hash_insert(),
+   hash_replace(), 또는 hash_delete() 함수를 사용하더라도,
+   DESTRUCTOR 내부나 외부에서 수행되는지에 관계없이 정의되지 않은 동작을 유발합니다. */
 /* Removes all the elements from H.
 
    If DESTRUCTOR is non-null, then it is called for each element
@@ -67,6 +75,14 @@ hash_clear (struct hash *h, hash_action_func *destructor) {
 	h->elem_cnt = 0;
 }
 
+/* 해시 테이블 H를 파괴합니다.
+
+   DESTRUCTOR가 null이 아니면, 먼저 해시의 각 요소에 대해 호출됩니다.
+   DESTRUCTOR는 적절한 경우 해시 요소에 사용된 메모리를 해제할 수 있습니다.
+   그러나 hash_clear()가 실행되는 동안 해시 테이블 H를 수정하는 것은
+   hash_clear(), hash_destroy(), hash_insert(),
+   hash_replace(), 또는 hash_delete() 함수를 사용하더라도,
+   DESTRUCTOR 내부나 외부에서 수행되는지에 관계없이 정의되지 않은 동작을 유발합니다. */
 /* Destroys hash table H.
 
    If DESTRUCTOR is non-null, then it is first called for each

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -264,7 +264,7 @@ void donate_priority(void) {
     struct thread *holder;
 
     for (int i = 0; i < 8; i++) {
-        if (curr->wait_on_lock == NULL)
+        if (curr->wait_on_lock == NULL || curr->wait_on_lock->holder == NULL) //parallel 테스트를 위해 추가함
             return;
         holder = curr->wait_on_lock->holder;
         holder->priority = curr->priority;

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -175,7 +175,10 @@ page_fault (struct intr_frame *f) {
 
 	fault_addr = (void *) rcr2();
 
-	if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
+	// @project 2 용 페이지 폴트
+	// if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
+	// 	exit(-1);
+	if ( fault_addr == NULL)
 		exit(-1);
 
 	/* 인터럽트를 다시 켭니다 (CR2가 변경되기 전에 확실하게 읽을 수 있도록). */

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -178,7 +178,7 @@ page_fault (struct intr_frame *f) {
 	// @project 2 용 페이지 폴트
 	// if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
 	// 	exit(-1);
-	if ( fault_addr == NULL)
+	if (fault_addr == NULL || !is_user_vaddr(fault_addr))
 		exit(-1);
 
 	/* 인터럽트를 다시 켭니다 (CR2가 변경되기 전에 확실하게 읽을 수 있도록). */

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -175,11 +175,6 @@ page_fault (struct intr_frame *f) {
 
 	fault_addr = (void *) rcr2();
 
-	// @project 2 용 페이지 폴트
-	// if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
-	// 	exit(-1);
-	if (fault_addr == NULL || !is_user_vaddr(fault_addr))
-		exit(-1);
 
 	/* 인터럽트를 다시 켭니다 (CR2가 변경되기 전에 확실하게 읽을 수 있도록). */
 	/* Turn interrupts back on (they were only off so that we could

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -858,6 +858,7 @@ static bool lazy_load_segment(struct page *page, void *aux) {
 	off_t ofs = aux_meta->ofs;
 	uint32_t read_bytes = aux_meta->read_bytes;
 	uint32_t zero_bytes = aux_meta->zero_bytes;
+    // free(aux);  //@todo: free 맞는지 고민하기
 
     //@todo: assert 문 여기 선언하는거 맞는지 고민해보기
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -868,6 +869,8 @@ static bool lazy_load_segment(struct page *page, void *aux) {
 
     if (file_read(file, page->frame->kva, read_bytes) != (int)read_bytes) {
         palloc_free_page(page->frame->kva);
+        free(aux);  //@todo: free 맞는지 고민하기
+
         return false;
     }
     memset(page->frame->kva + read_bytes, 0, zero_bytes);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -934,6 +934,12 @@ static bool setup_stack(struct intr_frame *if_) {
      * TODO: You should mark the page is stack. */
     /* TODO: Your code goes here */
 
+    vm_alloc_page(VM_ANON, stack_bottom, true);
+    if(vm_claim_page(stack_bottom)) {
+        if_->rsp = USER_STACK;
+        //@todo: page가 stack 임을 표시하기
+        success = true;
+    }
     return success;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -24,6 +24,8 @@
 #include "vm/vm.h"
 #endif
 
+#include "threads/malloc.h"
+
 static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -858,7 +858,7 @@ static bool lazy_load_segment(struct page *page, void *aux) {
 	off_t ofs = aux_meta->ofs;
 	uint32_t read_bytes = aux_meta->read_bytes;
 	uint32_t zero_bytes = aux_meta->zero_bytes;
-    // free(aux);  //@todo: free 맞는지 고민하기
+    free(aux);  //@todo: swap in/swap out 제대로 구현하기 전까지는 여기서 aux free 해주기!
 
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
 
@@ -871,7 +871,6 @@ static bool lazy_load_segment(struct page *page, void *aux) {
         return false;
     }
     memset(page->frame->kva + read_bytes, 0, zero_bytes);
-
     return true;
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -920,6 +920,7 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;
+        ofs += page_read_bytes;
     }
     return true;
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -928,15 +928,15 @@ static bool setup_stack(struct intr_frame *if_) {
 
     /* TODO: Map the stack on stack_bottom and claim the page immediately.
      * TODO: If success, set the rsp accordingly.
-     * TODO: You should mark the page is stack. */
-    /* TODO: Your code goes here */
+     * TODO: You should mark the page is stack.
+     * TODO: Your code goes here */
 
-    vm_alloc_page(VM_ANON, stack_bottom, true);
+    if (!vm_alloc_page((VM_ANON | VM_MARKER_0), stack_bottom, true)) return false;
     if(vm_claim_page(stack_bottom)) {
         if_->rsp = USER_STACK;
-        //@todo: page가 stack 임을 표시하기
         success = true;
     }
+    
     return success;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -879,7 +879,14 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
         size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
         /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        void *aux = NULL;
+        struct aux *aux = malloc(sizeof(struct aux)); // @todo 잊지말고 free하자!
+        if(aux == NULL)
+            return false;
+        aux->file = file;
+        aux->ofs = ofs;
+        aux->read_bytes = page_read_bytes;
+        aux->zero_bytes = page_zero_bytes; 
+        
         if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, aux))
             return false;
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -860,10 +860,7 @@ static bool lazy_load_segment(struct page *page, void *aux) {
 	uint32_t zero_bytes = aux_meta->zero_bytes;
     // free(aux);  //@todo: free 맞는지 고민하기
 
-    //@todo: assert 문 여기 선언하는거 맞는지 고민해보기
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
-    ASSERT(pg_ofs(page->va) == 0);
-    ASSERT(ofs % PGSIZE == 0);
 
     file_seek(file, ofs);
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -178,7 +178,10 @@ void syscall_handler(struct intr_frame *f UNUSED) {
 
 void check_address(void *uaddr) {
     struct thread *cur = thread_current();
-    if (uaddr == NULL || is_kernel_vaddr(uaddr) || pml4_get_page(cur->pml4, uaddr) == NULL) {
+    // if (uaddr == NULL || is_kernel_vaddr(uaddr) || pml4_get_page(cur->pml4, uaddr) == NULL) {
+    //     exit(-1);
+    // }
+    if (uaddr == NULL || is_kernel_vaddr(uaddr)) {
         exit(-1);
     }
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -113,6 +113,9 @@ void syscall_init(void) {
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED) {
     uint64_t syscall_n = f->R.rax;
+#ifdef VM
+    thread_current()->rsp = f->rsp; // 커널 모드 시스템콜 시 추가
+#endif
     switch (syscall_n) {
         case SYS_HALT:
             halt();

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -77,6 +77,8 @@ uninit_initialize (struct page *page, void *kva) {
 static void
 uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
+	free(uninit->aux);
+	return;
 	/* TODO: Fill this function.
 	 * TODO: If you don't have anything to do, just return. */
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -79,6 +79,4 @@ uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
 	free(uninit->aux);
 	return;
-	/* TODO: Fill this function.
-	 * TODO: If you don't have anything to do, just return. */
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -218,6 +218,30 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	/* TODO: Validate the fault */ /* TODO: 오류를 유효성 검사하세요. */
 	/* TODO: Your code goes here */
 
+	if(spt_find_page(spt, addr)) 
+		return vm_do_claim_page (page);
+
+	if(not_present) {
+		PANIC("vm_try_handle_fault: not_present\n");
+		return false;
+	}
+	if(write) {
+		PANIC("vm_try_handle_fault: write\n");
+		return false;
+	}
+	if(user) {
+		PANIC("vm_try_handle_fault: user\n");
+		return false;
+	}
+
+	// 유효하지 않은 페이지 폴트 찾아주기
+    // 종류 1) 유효하지 않은 접근
+    // 종류 2) 쓰기 시도
+    // 종류 3) 페이지 존재 x
+    // 종류 4) 사용자 모드로 커널 모드 접근
+		// @todo: 핸들 검증 더 추가할것.
+
+
 	return vm_do_claim_page (page);
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -5,7 +5,7 @@
 #include "vm/vm.h"
 #include "vm/inspect.h"
 
-#include "vaddr.h"
+#include "threads/vaddr.h"
 
 /* 각 하위 시스템의 초기화 코드를 호출하여 가상 메모리 하위 시스템을 초기화합니다. */
 /* Initializes the virtual memory subsystem by invoking each subsystem's

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -253,9 +253,8 @@ vm_do_claim_page (struct page *page) {
 	/* TODO: 페이지 테이블 항목을 삽입하여 
 	 * 페이지의 VA를 프레임의 PA로 매핑합니다. */
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
-	// @todo: rw 모드 어떻게 넘겨줄지
 	
-	if (!pml4_set_page (thread_current()->pml4, page->va, frame->kva, true))
+	if (!pml4_set_page (thread_current()->pml4, page->va, frame->kva, page->is_writable))
 	{
 		vm_dealloc_page(frame);
 		return false;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -60,6 +60,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
+	/* vm_type 비트마스크 적용 */
+	enum vm_type check_type = type & VM_ANON;
+	if (!check_type) check_type | VM_FILE;
+
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 	/* upage가 이미 사용 중인지 여부를 확인합니다. */
 	/* Check wheter the upage is already occupied or not. */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -220,18 +220,28 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	/* TODO: Your code goes here */
 
 	//주소가 존재하지 않을 때
-	if (addr == NULL)
+	if (addr == NULL){
+		exit(-1);
 		return false;
+	}
+
 	//커널 가상 주소일 때
-	if (is_kernel_vaddr(addr))
+	if (is_kernel_vaddr(addr)) {
+		exit(-1);
 		return false;
+	}
 
 	if (not_present){
 		page = spt_find_page(spt, addr);
-
-		if (page == NULL) return false;
-		if (write == true && page->is_writable == false) return false;
-
+		if (page == NULL){
+			exit(-1);
+			return false;
+		}
+		if (write == true && page->is_writable == false){
+			exit(-1);
+			return false;
+		}
+		
 		return vm_do_claim_page (page);
 	}
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -83,16 +83,15 @@ err:
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
-	/* TODO: Fill this function. */
-	// @TODO hash find 로 해야할것같은데 우선은 순회하는 방법으로 구현해놓음.
-	struct hash_iterator i;
-	hash_first (&i, &spt->hash_pages);
-	while (hash_next (&i)) {
-		page = hash_entry(hash_cur(&i), struct page, hash_elem);
-		if(page->va == va)
-			return page;
+	struct hash_elem *elem;
+	page->va = va;
+	
+	elem = hash_find(&spt->hash_pages, &page->hash_elem);
+	
+	if (elem != NULL) {
+		return hash_entry (elem, struct page, hash_elem);
 	}
-	return page;
+	return NULL;
 }
 
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -110,14 +110,13 @@ err:
 /* Find VA from spt and return page. On error, return NULL. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = malloc(sizeof(struct page));
+	struct page page;
 	struct hash_elem *elem;
 	va = pg_round_down(va);
-	page->va = va;
+	page.va = va;
 	
-	elem = hash_find(&spt->hash_pages, &page->hash_elem);
+	elem = hash_find(&spt->hash_pages, &page.hash_elem);
 
-	free(page);
 	if (elem != NULL) {
 		return hash_entry (elem, struct page, hash_elem);
 	}

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -5,6 +5,8 @@
 #include "vm/vm.h"
 #include "vm/inspect.h"
 
+#include "vaddr.h"
+
 /* 각 하위 시스템의 초기화 코드를 호출하여 가상 메모리 하위 시스템을 초기화합니다. */
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -84,6 +86,7 @@ struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
 	struct hash_elem *elem;
+	va = pg_round_down(va);
 	page->va = va;
 	
 	elem = hash_find(&spt->hash_pages, &page->hash_elem);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -60,7 +60,6 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
-
 	/* upage가 이미 사용 중인지 여부를 확인합니다. */
 	/* Check wheter the upage is already occupied or not. */
 	if (spt_find_page (spt, upage) == NULL) {
@@ -69,12 +68,37 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		 * TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
 
 		/* TODO: 페이지를 spt에 삽입합니다. */
-
 		/* TODO: Create the page, fetch the initialier according to the VM type,
 		 * TODO: and then create "uninit" page struct by calling uninit_new. You
 		 * TODO: should modify the field after calling the uninit_new. */
 
 		/* TODO: Insert the page into the spt. */
+		struct page *page = malloc(sizeof(struct page));
+		if(page == NULL)
+			goto err;
+
+		bool (*initializer)(struct page *, enum vm_type, void *kva) = NULL;
+
+		switch (type)
+		{		
+			case VM_ANON:
+				initializer = anon_initializer;
+				break;
+			case VM_FILE:
+				initializer = file_backed_initializer;
+				break;
+			// case VM_PAGE_CACHE:
+			// 	initializer = cache_initializer;
+			// 	break;
+			
+			default:
+				goto err;
+		}
+		uninit_new (page, upage, init, type, aux, initializer);
+
+		page->is_writable = writable;
+
+		if(spt_insert_page(spt, page)) return true;
 	}
 err:
 	return false;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -101,6 +101,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		if(spt_insert_page(spt, page)) return true;
 	}
 err:
+	free(aux);  //@todo: free 맞는지 고민하기
+
 	return false;
 }
 


### PR DESCRIPTION
### Test Result

```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
30 of 141 tests failed.
```