### PR TITLE
munmap 기능 병합

### DIFF
--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -7,7 +7,11 @@ struct page;
 enum vm_type;
 
 struct file_page {
-	void *aux;
+	struct file *file;
+	off_t ofs;
+	uint32_t page_read_bytes;
+	uint32_t page_zero_bytes;
+	size_t length;
 };
 
 void vm_file_init (void);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -371,7 +371,7 @@ void process_exit(void) {
     palloc_free_multiple(cur->fdt, FDT_PAGES);
     file_close(cur->running);  // 2) 현재 실행 중인 파일도 닫는다.
 
-    process_cleanup(); //@todo: 이거 올려야한대. 왜요????
+    process_cleanup();
 
     // 3) 자식이 종료될 때까지 대기하고 있는 부모에게 signal을 보낸다.
     sema_up(&cur->wait_sema);
@@ -604,8 +604,8 @@ done:
     lock_release(&filesys_lock);
     /* 로드가 성공했든 실패했든 여기에 도착합니다. */
     /* We arrive here whether the load is successful or not. */
-    // if (!success)
-    //     file_close(file);
+    if (!success)
+        file_close(file);
         
     return success;
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -384,6 +384,10 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
         return NULL;
     }
 
+    if (pg_ofs(offset)) {
+        return NULL;
+    }
+
     // int a = (uint64_t)addr & (PGSIZE - 1); // @todo 삭제할것 for testing
     // 길이가 있는지
     if ((long)length <= 0) {
@@ -408,16 +412,11 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
 
     int fsize = filesize(fd);
 
-    if (fsize <= 0 || fsize <= offset || length <= offset) {
+    if (fsize <= 0 || fsize <= offset) {
         return NULL;
     }
     
     if (fsize < length) length = fsize;
-
-    // file = file_reopen(file);
-	// if (file == NULL) {
-	// 	return NULL;
-	// }
 	
     return do_mmap(addr, length, writable, file, offset);
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -414,15 +414,23 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
     
     if (fsize < length) length = fsize;
 
-    file = file_reopen(file);
-	if (file == NULL) {
-		return NULL;
-	}
+    // file = file_reopen(file);
+	// if (file == NULL) {
+	// 	return NULL;
+	// }
 	
     return do_mmap(addr, length, writable, file, offset);
 }
 
 void munmap (void *addr) {
-    printf("not yet\n");
+    /* addr 에 대한 매핑 해제
+        * 동일한 프로세서의 mmap이 호출했던 주소여야함.
+        * 프로세스가 exit 되면 mmap ㅍ매핑 해제하기
+        * 프로세스가 쓴 모든 페이지는 파일에 다시 기록
+        * 기록하지 않은 페이지는 기록 x 
+        * 그리고 나서야 페이지 목록에서 제거 
+    */
+    // struct page *page = spt_find_page(&thread_current()->spt, addr);
+    // spt_remove_page(&thread_current()->spt, page);
     return NULL;
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -245,14 +245,17 @@ int wait(pid_t) {
 
 bool create(const char *file, unsigned initial_size) {
     check_address(file);
+    lock_acquire(&filesys_lock);
     bool is_success = filesys_create(file, initial_size);
-
+    lock_release(&filesys_lock);
     return is_success;
 }
 
 bool remove(const char *file) {
     check_address(file);
+    lock_acquire(&filesys_lock);
     bool is_success = filesys_remove(file);
+    lock_release(&filesys_lock);
     return is_success;
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -423,14 +423,14 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
 }
 
 void munmap (void *addr) {
-    /* addr 에 대한 매핑 해제
-        * 동일한 프로세서의 mmap이 호출했던 주소여야함.
-        * 프로세스가 exit 되면 mmap ㅍ매핑 해제하기
-        * 프로세스가 쓴 모든 페이지는 파일에 다시 기록
-        * 기록하지 않은 페이지는 기록 x 
-        * 그리고 나서야 페이지 목록에서 제거 
-    */
-    // struct page *page = spt_find_page(&thread_current()->spt, addr);
-    // spt_remove_page(&thread_current()->spt, page);
-    return NULL;
+    struct page *page = spt_find_page(&thread_current()->spt, addr);
+    size_t length = page->file.length;
+
+    size_t page_cnt = (length + PGSIZE - 1) / PGSIZE;
+    struct file *file = page->file.file;
+    for (size_t i = 0; i < page_cnt; i++) {
+        do_munmap(addr);
+        addr += PGSIZE;
+    }
+    file_close(file);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -74,6 +74,7 @@ file_backed_destroy (struct page *page) {
 	}
 
 	list_remove(&page->frame->elem);
+	free(page->frame);
 
 	pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -73,6 +73,11 @@ do_mmap (void *addr, size_t length, int writable,
 	size_t zero_bytes = PGSIZE - read_bytes % PGSIZE;
 	off_t ofs = offset;
 
+	file = file_reopen(file);
+	if (file == NULL) {
+		return NULL;
+	}
+	
 	// ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
 	// ASSERT(pg_ofs(addr) == 0);
 	// ASSERT(offset % PGSIZE == 0);

--- a/vm/file.c
+++ b/vm/file.c
@@ -68,11 +68,10 @@ static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
 
-	if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+	if (pml4_is_dirty(thread_current()->pml4, page->va) && page->is_writable) {
 		file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->ofs);
 		pml4_set_dirty(thread_current()->pml4, page->va, false); // @todo: 어차피 클리어 해줄건데 왜필요함?
 	}
-
 	list_remove(&page->frame->elem);
 	free(page->frame);
 

--- a/vm/file.c
+++ b/vm/file.c
@@ -71,8 +71,9 @@ file_backed_destroy (struct page *page) {
 		file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->ofs);
 		pml4_set_dirty(thread_current()->pml4, page->va, false); // @todo: 어차피 클리어 해줄건데 왜필요함?
 	}
-	// file_close(file_page->file);
-	// free(file_page->aux); //@todo: 언제 aux 삭제 가능하냐
+
+	list_remove(&page->frame->elem);
+
 	pml4_clear_page(thread_current()->pml4, page->va);
 }
 

--- a/vm/file.c
+++ b/vm/file.c
@@ -43,6 +43,7 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	file_page->ofs = aux->ofs;
 	file_page->page_read_bytes = aux->read_bytes;
 	file_page->page_zero_bytes = aux->zero_bytes;
+	file_page->length = aux->length;
 
 	return true;
 }
@@ -130,12 +131,7 @@ do_mmap (void *addr, size_t length, int writable,
 /* Do the munmap */
 void
 do_munmap (void *addr) {
-	//addr 나를 호출한 syscall mummap 에서 인자로 받음.
-	//spt 찾기!
-	//length 계산
-	//수정 사항 반영 -> file_backed_destroy에서 해줘야 함 destroy 호출
-	//file_backed_destroy의 호출자는 이를 처리해야 합니다. -> 페이지 삭제
-	//
-
-	
+	struct page *page;
+	page = spt_find_page(&thread_current()->spt, addr);
+	spt_remove_page(&thread_current()->spt, page);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -33,11 +33,16 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* 핸들러 설정 */
 	/* Set up the handler */
 	page->operations = &file_ops;
-	struct aux *aux = malloc(sizeof(struct aux));
-	memcpy(aux, page->uninit.aux, sizeof(struct aux));
+
 	struct file_page *file_page = &page->file;
-	file_page->aux = &aux;
-	
+	struct aux *aux = (struct aux *)page->uninit.aux;
+
+	file_page->file = aux->file;
+	file_page->ofs = aux->ofs;
+	file_page->page_read_bytes = aux->read_bytes;
+	file_page->page_zero_bytes = aux->zero_bytes;
+
+	return true;
 }
 
 /* 파일에서 내용을 읽어 페이지를 스왑 인합니다. */

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -77,6 +77,7 @@ uninit_initialize (struct page *page, void *kva) {
 static void
 uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
+	//@todo: pml4 clear page 안함?
 	free(uninit->aux);
 	return;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -152,8 +152,8 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
-	hash_delete(&spt->hash_pages, page);
-	list_remove(&page->frame->elem);
+	hash_delete(&spt->hash_pages, &page->hash_elem);
+	// list_remove(&page->frame->elem);
 	vm_dealloc_page (page);
 	return true;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -410,6 +410,5 @@ page_destructor (struct hash_elem *page_elem, void *aux UNUSED){
 	// }
 
 	//@todo: 동적으로 할당받은게 뭐가 있는지 조사 후 추가
-	destroy(p); // page vm_type 별로 destroy 함수 호출
-	free(p);
+	vm_dealloc_page(p);
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -404,10 +404,6 @@ page_destructor (struct hash_elem *page_elem, void *aux UNUSED){
 	if (page_elem == NULL) return;
 
 	struct page *p = hash_entry(page_elem, struct page, hash_elem);
-	
-	// if (p != NULL){
-	// 	list_remove(&p->frame->elem);
-	// }
 
 	//@todo: 동적으로 할당받은게 뭐가 있는지 조사 후 추가
 	vm_dealloc_page(p);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -152,6 +152,7 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
+	hash_delete(&spt->hash_pages, page);
 	list_remove(&page->frame->elem);
 	vm_dealloc_page (page);
 	return true;


### PR DESCRIPTION
file_page destroy  구현

spt_table, page_table, frame_table에서 삭제되는 페이지 요소도 리스트에서 빠지도록 구현

쓰기 가능일시에만 디스트로이하면서 작성하도록.