### PR TITLE
Swap in out 구현

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -5,6 +5,7 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+  size_t swap_idx;
 };
 
 void vm_anon_init (void);

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -4,9 +4,16 @@
 #include "vm/vm.h"
 #include "devices/disk.h"
 
+#include <bitmap.h>
+
+#include "threads/mmu.h"
+
+static struct disk *swap_disk;
+struct bitmap *swap_table;
+struct lock bitmap_lock;
 /* 아래 줄을 수정하지 마세요 */
 /* DO NOT MODIFY BELOW LINE */
-static struct disk *swap_disk;
+
 static bool anon_swap_in (struct page *page, void *kva);
 static bool anon_swap_out (struct page *page);
 static void anon_destroy (struct page *page);
@@ -26,7 +33,9 @@ void
 vm_anon_init (void) {
 	/* 할 일: 스왑 디스크를 설정하세요. */
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+	swap_disk = disk_get(1, 1);
+	swap_table = bitmap_create(disk_size(swap_disk) / 8); // 디스크는 섹터(512바이트) 단위로 관리함 그래서 8 섹터가 있어야 하나의 페이지를 저장가능
+	lock_init(&bitmap_lock);
 }
 
 /* 파일 매핑 초기화 */
@@ -38,6 +47,9 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
+	anon_page->swap_idx = BITMAP_ERROR;
+
+	return true;
 }
 
 /* 스왑 디스크에서 내용을 읽어 페이지를 스왑 인합니다. */
@@ -45,6 +57,27 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
+
+	size_t swap_idx = anon_page->swap_idx;
+	if (!bitmap_test(swap_table, swap_idx)) {
+		return false;
+	}
+	if (swap_idx == BITMAP_ERROR) {
+		PANIC("swap_in idx is crazy");
+		return false;
+	}
+
+	for (int i = 0; i < 8; i++) {
+		disk_read(swap_disk, swap_idx * 8 + i, kva + i * DISK_SECTOR_SIZE);
+	}
+
+	page->frame->kva = kva;
+
+	lock_acquire(&bitmap_lock);
+	bitmap_set(swap_table, swap_idx, false);
+	lock_release(&bitmap_lock);
+
+	return true;
 }
 
 /* 내용을 스왑 디스크에 쓰면서 페이지를 스왑 아웃합니다. */
@@ -52,6 +85,25 @@ anon_swap_in (struct page *page, void *kva) {
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+
+	lock_acquire(&bitmap_lock);
+	size_t swap_idx = bitmap_scan_and_flip(swap_table, 0, 1, false);
+	lock_release(&bitmap_lock);
+	if (swap_idx == BITMAP_ERROR) {
+		return false;
+	}
+	anon_page->swap_idx = swap_idx;
+
+	for (int i = 0; i < 8; i++) {
+		disk_write(swap_disk, swap_idx * 8 + i, page->frame->kva + DISK_SECTOR_SIZE * i);
+	}
+
+	page->frame->page = NULL;
+	page->frame = NULL;
+	
+	
+	pml4_clear_page(thread_current()->pml4, page->va);
+	return true;
 }
 
 /* 익명 페이지를 파괴합니다. PAGE는 호출자에 의해 해제될 것입니다. */

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -111,4 +111,22 @@ anon_swap_out (struct page *page) {
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	
+	// 스왑 테이블에서 스왑 인덱스 해제
+	if (anon_page->swap_idx != BITMAP_ERROR) {
+		lock_acquire(&bitmap_lock);
+		bitmap_reset(swap_table, anon_page->swap_idx);
+		lock_release(&bitmap_lock);
+	}
+
+	// 프레임이 존재하면 프레임을 리스트에서 제거하고 해제
+	if (page->frame) {
+		list_remove(&page->frame->elem);
+		page->frame->page = NULL;
+		palloc_free_page(page->frame->kva);
+		free(page->frame);
+		page->frame = NULL;
+	}
+
+	pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -72,8 +72,14 @@ file_backed_destroy (struct page *page) {
 		file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->ofs);
 		pml4_set_dirty(thread_current()->pml4, page->va, false); // @todo: 어차피 클리어 해줄건데 왜필요함?
 	}
-	list_remove(&page->frame->elem);
-	free(page->frame);
+
+	if (page->frame) {
+		list_remove(&page->frame->elem);
+		page->frame->page = NULL;
+		page->frame = NULL;
+		free(page->frame);
+	}
+
 
 	pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -89,7 +89,9 @@ do_mmap (void *addr, size_t length, int writable,
 	size_t zero_bytes = PGSIZE - read_bytes % PGSIZE;
 	off_t ofs = offset;
 
+	lock_acquire(&filesys_lock);
 	file = file_reopen(file);
+	lock_release(&filesys_lock);
 	if (file == NULL) {
 		return NULL;
 	}


### PR DESCRIPTION
```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
pass tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
pass tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
pass tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
pass tests/vm/swap-file
pass tests/vm/swap-anon
pass tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
2 of 141 tests failed.
```